### PR TITLE
Fix incompatibility with newer/different MySQL drivers (Fixes #14)

### DIFF
--- a/src/main/java/codecrafter47/bungeemail/MySQLBackend.java
+++ b/src/main/java/codecrafter47/bungeemail/MySQLBackend.java
@@ -31,12 +31,6 @@ public class MySQLBackend implements IStorageBackend {
     }
 
     private void setupDataSource(BungeeMail plugin) {
-        try {
-            Class.forName("com.mysql.jdbc.jdbc2.optional.MysqlDataSource");
-        } catch (ClassNotFoundException var2) {
-            plugin.getLogger().warning("MySQL DataSource class missing: " + var2.getMessage() + ".");
-            throw new RuntimeException("Failed to connect to MySql database");
-        }
         ConnectionFactory connectionFactory = new DriverManagerConnectionFactory("jdbc:mysql://" + plugin.config.getString("mysql_hostname") + ":" + plugin.config.getInt("mysql_port") + "/" + plugin.config.getString("mysql_database"), plugin.config.getString("mysql_username"), plugin.config.getString("mysql_password"));
         PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
         GenericObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<>(poolableConnectionFactory);


### PR DESCRIPTION
This removes the check for one specific MySQL driver as that broke on the updated MySQL drivers. (And when using a different driver like MariaDB alltogether)

This check didn't really do anything (the jdbc driver was still dynamically selected afterwards) and if there really is no driver then it will just fail. (Maybe the exception won't be as pretty but the end result of the plugin not working would be the same)